### PR TITLE
Add FFFA to magic bytes for MP3. Fixes #10

### DIFF
--- a/matchers/audio.go
+++ b/matchers/audio.go
@@ -29,6 +29,7 @@ func Midi(buf []byte) bool {
 func Mp3(buf []byte) bool {
 	return len(buf) > 2 &&
 		((buf[0] == 0x49 && buf[1] == 0x44 && buf[2] == 0x33) ||
+			(buf[0] == 0xFF && buf[1] == 0xfa) ||
 			(buf[0] == 0xFF && buf[1] == 0xfb))
 }
 


### PR DESCRIPTION
This resolves the problem for me with mono-channel MP3 files. Please let me know if any changes are required, e.g. for code style. Thanks.