### PR TITLE
add heif/heic support

### DIFF
--- a/matchers/image.go
+++ b/matchers/image.go
@@ -1,5 +1,7 @@
 package matchers
 
+import "github.com/h2non/filetype/matchers/isobmff"
+
 var (
 	TypeJpeg     = newType("jpg", "image/jpeg")
 	TypeJpeg2000 = newType("jp2", "image/jp2")
@@ -12,6 +14,7 @@ var (
 	TypeJxr      = newType("jxr", "image/vnd.ms-photo")
 	TypePsd      = newType("psd", "image/vnd.adobe.photoshop")
 	TypeIco      = newType("ico", "image/x-icon")
+	TypeHeic     = newType("heic", "image/heic")
 )
 
 var Image = Map{
@@ -26,6 +29,7 @@ var Image = Map{
 	TypeJxr:      Jxr,
 	TypePsd:      Psd,
 	TypeIco:      Ico,
+	TypeHeic:     Heic,
 }
 
 func Jpeg(buf []byte) bool {
@@ -105,4 +109,25 @@ func Ico(buf []byte) bool {
 	return len(buf) > 3 &&
 		buf[0] == 0x00 && buf[1] == 0x00 &&
 		buf[2] == 0x01 && buf[3] == 0x00
+}
+
+func Heic(buf []byte) bool {
+	if !isobmff.IsISOBMFF(buf) {
+		return false
+	}
+
+	majorBrand, _, compatibleBrands := isobmff.GetFtyp(buf)
+	if majorBrand == "heic" {
+		return true
+	}
+
+	if majorBrand == "mif1" || majorBrand == "msf1" {
+		for _, compatibleBrand := range compatibleBrands {
+			if compatibleBrand == "heic" {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/matchers/isobmff/isobmff.go
+++ b/matchers/isobmff/isobmff.go
@@ -1,0 +1,31 @@
+package isobmff
+
+import "encoding/binary"
+
+// IsISOBMFF checks whether the given buffer represents ISO Base Media File Format data
+func IsISOBMFF(buf []byte) bool {
+	if len(buf) < 16 || string(buf[4:8]) != "ftyp" {
+		return false
+	}
+
+	if ftypLength := binary.BigEndian.Uint32(buf[0:4]); len(buf) < int(ftypLength) {
+		return false
+	}
+
+	return true
+}
+
+// GetFtyp returns the major brand, minor version and compatible brands of the ISO-BMFF data
+func GetFtyp(buf []byte) (string, string, []string) {
+	ftypLength := binary.BigEndian.Uint32(buf[0:4])
+
+	majorBrand := string(buf[8:12])
+	minorVersion := string(buf[12:16])
+
+	compatibleBrands := []string{}
+	for i := 16; i < int(ftypLength); i += 4 {
+		compatibleBrands = append(compatibleBrands, string(buf[i:i+4]))
+	}
+
+	return majorBrand, minorVersion, compatibleBrands
+}


### PR DESCRIPTION
ported over the logic from [filetype.py/isobmff.py](https://github.com/h2non/filetype.py/blob/c1485feee1b3e9397bad8f701f9a727a60291356/filetype/types/isobmff.py).