### PR TITLE
Better matching and differentiation between CR2 and Tiff

### DIFF
--- a/matchers/image.go
+++ b/matchers/image.go
@@ -76,18 +76,18 @@ func Webp(buf []byte) bool {
 }
 
 func CR2(buf []byte) bool {
-	return len(buf) > 9 &&
-		((buf[0] == 0x49 && buf[1] == 0x49 && buf[2] == 0x2A && buf[3] == 0x0) ||
-			(buf[0] == 0x4D && buf[1] == 0x4D && buf[2] == 0x0 && buf[3] == 0x2A)) &&
-		buf[8] == 0x43 && buf[9] == 0x52
+	return len(buf) > 10 &&
+		((buf[0] == 0x49 && buf[1] == 0x49 && buf[2] == 0x2A && buf[3] == 0x0) || // Little Endian
+			(buf[0] == 0x4D && buf[1] == 0x4D && buf[2] == 0x0 && buf[3] == 0x2A)) && // Big Endian
+		buf[8] == 0x43 && buf[9] == 0x52 && // CR2 magic word
+		buf[10] == 0x02 // CR2 major version
 }
 
 func Tiff(buf []byte) bool {
-	return len(buf) > 9 &&
-		((buf[0] == 0x49 && buf[1] == 0x49 && buf[2] == 0x2A && buf[3] == 0x0) ||
-			(buf[0] == 0x4D && buf[1] == 0x4D && buf[2] == 0x0 && buf[3] == 0x2A)) &&
-		// Differentiate Tiff from CR2
-		buf[8] != 0x43 && buf[9] != 0x52
+	return len(buf) > 10 &&
+		((buf[0] == 0x49 && buf[1] == 0x49 && buf[2] == 0x2A && buf[3] == 0x0) || // Little Endian
+			(buf[0] == 0x4D && buf[1] == 0x4D && buf[2] == 0x0 && buf[3] == 0x2A)) && // Big Endian
+		!CR2(buf) // To avoid conflicts differentiate Tiff from CR2
 }
 
 func Bmp(buf []byte) bool {


### PR DESCRIPTION
The standard for Canon Raw files, CR2 files is based on the tiff format. Therefore the initial first 4 bytes are the same. The difference is in byte 8-10.

The goal is to only match Tiff image if a CR2 image is not matched.

Thanks.

Source: http://lclevy.free.fr/cr2/#key_info
Offset | Length | Type | Description | Value
-- | -- | -- | -- | --
0x0000 | 2 | char | Byte order | "II" or 0x4949 means Intel byte order (little endian)"MM" or 0x4d4d means Motorola byte order (big endian)
0x0002 | 1 | short | TIFF magic word | 0x002a
0x0004 | 1 | long | TIFF offset | 0x0000 0010
0x0008 | 1 | short | CR2 magic word | "CR" or 0x4352
0x000a | 1 | char | CR2 major version | 2
0x000b | 1 | char | CR2 minor version | 0
0x000c | 1 | long | RAW IFD offset



