### PR TITLE
Add support for parent/child TypeMatchers

### DIFF
--- a/filetype.go
+++ b/filetype.go
@@ -43,19 +43,17 @@ func IsExtension(buf []byte, ext string) bool {
 
 // IsType checks if a given buffer matches with the given file type
 func IsType(buf []byte, kind types.Type) bool {
-	matcher := matchers.Matchers[kind]
-	if matcher == nil {
-		return false
+	if matcher, ok := matchers.Matchers[kind]; ok {
+		return matcher.Match(buf)
 	}
-	return matcher(buf) != types.Unknown
+	return false
 }
 
 // IsMIME checks if a given buffer matches with the given MIME type
 func IsMIME(buf []byte, mime string) bool {
 	for _, kind := range types.Types {
 		if kind.MIME.Value == mime {
-			matcher := matchers.Matchers[kind]
-			return matcher(buf) != types.Unknown
+			return IsType(buf, kind)
 		}
 	}
 	return false

--- a/match.go
+++ b/match.go
@@ -25,13 +25,12 @@ func Match(buf []byte) (types.Type, error) {
 	}
 
 	for _, kind := range *MatcherKeys {
-		checker := Matchers[kind]
-		match := checker(buf)
+		matcher := Matchers[kind]
+		match := matcher.Type(buf)
 		if match != types.Unknown && match.Extension != "" {
 			return match, nil
 		}
 	}
-
 	return types.Unknown, nil
 }
 
@@ -64,7 +63,7 @@ func MatchReader(reader io.Reader) (types.Type, error) {
 }
 
 // AddMatcher registers a new matcher type
-func AddMatcher(fileType types.Type, matcher matchers.Matcher) matchers.TypeMatcher {
+func AddMatcher(fileType types.Type, matcher matchers.ByteMatcher) matchers.TypeMatcher {
 	return matchers.NewMatcher(fileType, matcher)
 }
 

--- a/match_test.go
+++ b/match_test.go
@@ -120,6 +120,42 @@ func TestAddMatcher(t *testing.T) {
 	}
 }
 
+func TestAddChild(t *testing.T) {
+	parentType := AddType("fooparent", "foo/parent")
+	parentFn := func(buf []byte) bool {
+		return len(buf) >= 2 && buf[0] == 0x00 && buf[1] == 0x00
+	}
+	parentMatcher := AddMatcher(parentType, parentFn)
+
+	childType := AddType("foochild", "foo/child")
+	childFn := func(buf []byte) bool {
+		return len(buf) > 2 &&
+			buf[0] == 0x00 && buf[1] == 0x00 && buf[2] == 0x00
+	}
+	parentMatcher.AddChild(childType, childFn)
+
+	if !Is([]byte{0x00, 0x00}, "fooparent") {
+		t.Fatalf("Parent cannot match")
+	}
+
+	if !Is([]byte{0x00, 0x00, 0x00}, "foochild") {
+		t.Fatalf("Child cannot match")
+	}
+
+	if !Is([]byte{0x00, 0x00, 0x00}, "fooparent") {
+		t.Fatalf("Parent does not match child")
+	}
+
+	if !IsSupported("foochild") {
+		t.Fatalf("Not supported extension")
+	}
+
+	if !IsMIMESupported("foo/child") {
+		t.Fatalf("Not supported MIME type")
+	}
+
+}
+
 func TestMatchMap(t *testing.T) {
 	cases := []struct {
 		buf  []byte

--- a/matchers/archive.go
+++ b/matchers/archive.go
@@ -30,8 +30,8 @@ var (
 )
 
 var Archive = Map{
-	TypeEpub:   Epub,
 	TypeZip:    Zip,
+	TypeEpub:   ChildMatcher(TypeZip, TypeEpub, Epub),
 	TypeTar:    Tar,
 	TypeRar:    Rar,
 	TypeGz:     Gz,

--- a/matchers/children.go
+++ b/matchers/children.go
@@ -1,0 +1,22 @@
+package matchers
+
+import (
+	"github.com/h2non/filetype/types"
+)
+
+// Store any types with registered children
+var ChildMatchers = make(map[types.Type][]TypeMatcher)
+
+// ChildMatcher creates a TypeMatcher as a child of the parent Type
+func ChildMatcher(parent types.Type, kind types.Type, fn ByteMatcher) ByteMatcher {
+	matcher := NewMatcher(kind, fn)
+	ChildMatchers[parent] = append(ChildMatchers[parent], matcher)
+	return fn
+}
+
+// AddChild creates and registers a new child for a TypeMatcher
+func (m TypeMatcher) AddChild(kind types.Type, fn ByteMatcher) {
+	_ = ChildMatcher(m.myType, kind, fn)
+}
+
+

--- a/matchers/matchers.go
+++ b/matchers/matchers.go
@@ -7,32 +7,67 @@ import (
 // Internal shortcut to NewType
 var newType = types.NewType
 
-// Matcher function interface as type alias
-type Matcher func([]byte) bool
+type Matcher interface {
+	Match([]byte) bool
+}
 
-// Type interface to store pairs of type with its matcher function
-type Map map[types.Type]Matcher
+type Typer interface {
+	Type([]byte) types.Type
+}
 
-// Type specific matcher function interface
-type TypeMatcher func([]byte) types.Type
+// ByteMatcher function interface as type alias
+type ByteMatcher func([]byte) bool
+
+// Implement Matcher interface for ByteMatcher
+func (b ByteMatcher) Match(buf []byte) bool {
+	return b(buf)
+}
+
+// A TypeMatcher is both a Typer and Matcher
+type TypeMatcher struct {
+	myType  types.Type
+	matcher ByteMatcher
+}
+
+// Implement Matcher interface for TypeMatcher
+func (m TypeMatcher) Match(buf []byte) bool {
+	// Check any matchers for child types
+	for _, c := range ChildMatchers[m.myType] {
+		if c.matcher.Match(buf) {
+			return true
+		}
+	}
+	return m.matcher.Match(buf)
+}
+
+// Implement Typer interface for TypeMatcher
+func (m TypeMatcher) Type(buf []byte) types.Type {
+	// Return a matching child type, if any
+	for _, c := range ChildMatchers[m.myType] {
+		if c.matcher.Match(buf) {
+			return c.myType
+		}
+	}
+	if m.matcher.Match(buf) {
+		return m.myType
+	}
+	return types.Unknown
+}
 
 // Store registered file type matchers
 var Matchers = make(map[types.Type]TypeMatcher)
 var MatcherKeys []types.Type
 
-// Create and register a new type matcher function
-func NewMatcher(kind types.Type, fn Matcher) TypeMatcher {
-	matcher := func(buf []byte) types.Type {
-		if fn(buf) {
-			return kind
-		}
-		return types.Unknown
-	}
+// Type interface to store pairs of type with its matcher
+type Map map[types.Type]ByteMatcher
 
-	Matchers[kind] = matcher
+// Create and register a new type matcher
+func NewMatcher(kind types.Type, fn ByteMatcher) TypeMatcher {
+	m := TypeMatcher{kind, fn}
+	Matchers[kind] = m
 	// prepend here so any user defined matchers get added first
 	MatcherKeys = append([]types.Type{kind}, MatcherKeys...)
-	return matcher
+	return m
 }
 
 func register(matchers ...Map) {


### PR DESCRIPTION
Going a different route from #73, this PR modifies the matchers interface to account for parent/child relationships between types. (I initially called the children `subtypes`, as you can see from the branch name, but since that term's already used in the MIME code it would've been confusing as heck.) 

### Modifications to existing code
#### `matchers/matchers.go`
* Two new interfaces are added, `Matcher` and `Typer`
    * The `Matcher` interface requires a method, `Match([]bytes)`, which returns `true` if the buffer matches the matching function
    * The `Typer` interface adds Type([]bytes)`, which returns the associated `types.Type` if the buffer matches the matching function
* The matching function type is renamed to `ByteMatcher`
    * `ByteMacher` implements `Matcher`
* `TypeMatcher` is now a struct, containing a `types.Type` and a `ByteMatcher`
* `TypeMatcher` implements both `Matcher` and `Typer`
   * `TypeMatcher.Match()` checks whether the buffer matches the type **or any of its child types**
   * `TypeMatcher.Type()` checks the buffer against any child types, _then_ the parent type, and returns the type on successful match
* `ChildMatchers` is a `map[types.Type][]TypeMatcher` which registers the parent-child relationship between a `Type` and its child `TypeMatchers` (not directly between `TypeMatchers`)

#### `match.go`
* The matching code is updated to use the `Match()` and `Type()` methods, instead of running `ByteMatchers` directly.

#### `filetype.go`
* The `Is()` and `IsType()` functions now use `Match()` and `Type()`, instead of running `ByteMatchers` directly. (Actually, `Is` now just calls `IsType`, which checks the type's `TypeMatcher.Match()`.)
   * `Is()` and `IsType()` will return _true_ for both a buffer's specific type, and its parent type. (e.g. `IsType(types.TypeZip)` and `Is("zip")` are true for a buffer containing `.docx` bytes.)

### New source files

The new file `matchers/children.go` adds storage for the the parent-child mappings:
* `TypeMatcher` is expanded with an `AddChild(types.Type, ByteMatcher)` method, to add a child of the matcher's `Type`
* A non-method `AddChildType(parent, child types.Type, ByteMatcher)` is also added, to create children for types that don't yet have a `TypeMatcher`. (This was necessary to keep the `matchers.Map{}` functionality working, since `ChildMatchers` will end up getting populated _before_ `Matchers`.)

### Updates to existing data structures

* `Epub`, `Docx`, `Xlsx`, and `Pptx` are all made children of `TypeZip`

### Testing 

* A new unit test verifies `ChildMatcher` functionality

### Notes/Caveats
In theory this could be extended to support a multi-level hierarchy, with child types having children of their own. However, as that wasn't necessary to support current needs, only one level is implemented. The `Type()` method of `TypeMatcher` doesn't use the `Type()` method of its children to look up their matching types, it queries the child's `ByteMatcher` directly. Recursive `ChildMatcher` lookups would be necessary to support children of children.

There's no way to support parent-child relationships in an arbitrary `MatchMap()` call. Because it _does_ run the `ByteMatcher`s it's passed directly, it will ignore `ChildMatchers` and can return incorrect results if it's passed a `matchers.Map` containing overlapping matchers.

Fixes #38, fixes #40
