### PR TITLE
check quicktime for 'ftype qt  ' magic numbers

### DIFF
--- a/matchers/video.go
+++ b/matchers/video.go
@@ -49,15 +49,14 @@ func Webm(buf []byte) bool {
 		buf[2] == 0xDF && buf[3] == 0xA3 &&
 		containsMatroskaSignature(buf, []byte{'w', 'e', 'b', 'm'})
 }
-
 func Mov(buf []byte) bool {
-	return len(buf) > 15 && ((buf[0] == 0x0 && buf[1] == 0x0 &&
-		buf[2] == 0x0 && buf[3] == 0x14 &&
-		buf[4] == 0x66 && buf[5] == 0x74 &&
-		buf[6] == 0x79 && buf[7] == 0x70) ||
-		(buf[4] == 0x6d && buf[5] == 0x6f && buf[6] == 0x6f && buf[7] == 0x76) ||
-		(buf[4] == 0x6d && buf[5] == 0x64 && buf[6] == 0x61 && buf[7] == 0x74) ||
-		(buf[12] == 0x6d && buf[13] == 0x64 && buf[14] == 0x61 && buf[15] == 0x74))
+  return len(buf) > 15 && (
+    (buf[4] == 0x66 && buf[5] == 0x74 && buf[6] == 0x79 && buf[7] == 0x70) &&
+      ((buf[8] == 0x71 && buf[9] == 0x74 && buf[10] == 0x20 && buf[11] == 0x20) ||
+        (buf[0] == 0x0 && buf[1] == 0x0 && buf[2] == 0x0 && buf[3] == 0x14)) ||
+    (buf[4] == 0x6d && buf[5] == 0x6f && buf[6] == 0x6f && buf[7] == 0x76) ||
+    (buf[4] == 0x6d && buf[5] == 0x64 && buf[6] == 0x61 && buf[7] == 0x74) ||
+    (buf[12] == 0x6d && buf[13] == 0x64 && buf[14] == 0x61 && buf[15] == 0x74))
 }
 
 func Avi(buf []byte) bool {


### PR DESCRIPTION
This PR adds a match case for quicktime movie files that ignores the first four bytes of the first atom but looks for a Type of 'ftyp' and a Major Brand of 'qt '.

It seems that filetype sometimes fails to identify quicktime videos where the first four bytes aren't 0x0,0x0,0x0,0x14 and the 13-16th bytes aren't the type field for an mdat atom. Possibly this is when the first atom is a File Type Compatibility Atom. By adding a case where we ignore the first field (presumably Size) and instead match on the Type and Major Brand fields we hope to catch some mov files that would otherwise be missed.

For reference here is this doc from Apple https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap1/qtff1.html#//apple_ref/doc/uid/TP40000939-CH203-CJBCBIFF which describes an atom that matches our case:

    The file type atom has an atom type value of 'ftyp' and contains the following fields:
    Size
    A 32-bit unsigned integer that specifies the number of bytes in this atom.
    Type
    A 32-bit unsigned integer that identifies the atom type, typically represented as a four-character code; this field must be set to 'ftyp'.
    Major_Brand
    A 32-bit unsigned integer that should be set to 'qt ' (note the two trailing ASCII space characters) for QuickTime movie files.

This is the first PR I've opened here so if there is any procedure I've missed please let me know.