### PR TITLE
Add AIFF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ func main() {
 - **wav** - `audio/x-wav`
 - **amr** - `audio/amr`
 - **aac** - `audio/aac`
+- **aiff** - `audio/x-aiff`
 
 #### Archive
 

--- a/matchers/audio.go
+++ b/matchers/audio.go
@@ -9,6 +9,7 @@ var (
 	TypeWav  = newType("wav", "audio/x-wav")
 	TypeAmr  = newType("amr", "audio/amr")
 	TypeAac  = newType("aac", "audio/aac")
+	TypeAiff = newType("aiff", "audio/x-aiff")
 )
 
 var Audio = Map{
@@ -20,6 +21,7 @@ var Audio = Map{
 	TypeWav:  Wav,
 	TypeAmr:  Amr,
 	TypeAac:  Aac,
+	TypeAiff: Aiff,
 }
 
 func Midi(buf []byte) bool {
@@ -72,4 +74,12 @@ func Aac(buf []byte) bool {
 	return len(buf) > 1 &&
 		((buf[0] == 0xFF && buf[1] == 0xF1) ||
 			(buf[0] == 0xFF && buf[1] == 0xF9))
+}
+
+func Aiff(buf []byte) bool {
+	return len(buf) > 11 &&
+		buf[0] == 0x46 && buf[1] == 0x4F &&
+		buf[2] == 0x52 && buf[3] == 0x4D &&
+		buf[8] == 0x41 && buf[9] == 0x49 &&
+		buf[10] == 0x46 && buf[11] == 0x46
 }


### PR DESCRIPTION
This pull request adds support for AIFF files. The specification can be found here: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/Docs/AIFF-1.3.pdf

I chose `aiff` for the extension since this seems to be the more common one (from what I've seen) compared to `aif`.

To keep consistency, I also chose `audio/x-aiff` over `audio/aiff` for the MIME type.