### PR TITLE
[fix] office 2007 word without .rels file

### DIFF
--- a/matchers/document.go
+++ b/matchers/document.go
@@ -102,7 +102,8 @@ func msooxml(buf []byte) (typ docType, found bool) {
 
 	if !compareBytes(buf, []byte("[Content_Types].xml"), 0x1E) &&
 		!compareBytes(buf, []byte("_rels/.rels"), 0x1E) &&
-		!compareBytes(buf, []byte("docProps"), 0x1E) {
+		!compareBytes(buf, []byte("docProps"), 0x1E) &&
+		!compareBytes(buf, []byte("_rels"), 0x1E) {
 		return
 	}
 


### PR DESCRIPTION
office 2007 word file only has directory _rels without .rels file