### PR TITLE
support block size 0x20 for mov file

### DIFF
--- a/matchers/video.go
+++ b/matchers/video.go
@@ -52,7 +52,7 @@ func Webm(buf []byte) bool {
 
 func Mov(buf []byte) bool {
 	return len(buf) > 15 && ((buf[0] == 0x0 && buf[1] == 0x0 &&
-		buf[2] == 0x0 && buf[3] == 0x14 &&
+		buf[2] == 0x0 && (buf[3] == 0x14 || buf[3] == 0x20) &&
 		buf[4] == 0x66 && buf[5] == 0x74 &&
 		buf[6] == 0x79 && buf[7] == 0x70) ||
 		(buf[4] == 0x6d && buf[5] == 0x6f && buf[6] == 0x6f && buf[7] == 0x76) ||


### PR DESCRIPTION
current mov file check only consider block size 0x14. Some files has size 0x20, like https://www.file-recovery.com/mov-signature-format.htm, https://docs.fileformat.com/video/mov/#file-structure-of-mov-files

one example of the first 32 bytes with block size 0x20

00000000: 0000 0020 6674 7970 7174 2020 2005 0300  ... ftypqt   ...
00000010: 7174 2020 0000 0000 0000 0000 0000 0000  qt  ............

one example of the first 32 bybtes with block size 0x14

00000000: 0000 0014 6674 7970 7174 2020 0000 0200  ....ftypqt  ....
00000010: 7174 2020 0000 0008 7769 6465 000a 7769  qt  ....wide..wi