### PR TITLE
Fix file header example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ package main
 
 import (
   "fmt"
-  "io/ioutil"
+  "os"
 
   "github.com/h2non/filetype"
 )


### PR DESCRIPTION
Remove unused `io/ioutil` package and add used `os` package.

Follow up of #28.