### PR TITLE
match xls formats: biff5,biff8(11),biff8(12)

### DIFF
--- a/matchers/document.go
+++ b/matchers/document.go
@@ -64,14 +64,17 @@ func Docx(buf []byte) bool {
 
 func Xls(buf []byte) bool {
 	if len(buf) > 513 {
-		return buf[0] == 0xD0 && buf[1] == 0xCF &&
-			buf[2] == 0x11 && buf[3] == 0xE0 &&
-			buf[512] == 0x09 && buf[513] == 0x08
-	} else {
-		return len(buf) > 3 &&
-			buf[0] == 0xD0 && buf[1] == 0xCF &&
-			buf[2] == 0x11 && buf[3] == 0xE0
+		isMSOfficeBFF := buf[0] == 0xD0 && buf[1] == 0xCF && buf[2] == 0x11 && buf[3] == 0xE0
+
+		switch {
+		case isMSOfficeBFF && buf[512] == 0x09 && buf[513] == 0x08: // BIFF5 && BIFF12(12)
+			return true
+		case isMSOfficeBFF && buf[512] == 0xFD && buf[513] == 0xFF: // BIFF12(11)
+			return true
+		}
 	}
+
+	return false
 }
 
 func Xlsx(buf []byte) bool {


### PR DESCRIPTION
Hi. Xls-matcher can't recognize xls BIFF8(11).  Here https://www.openoffice.org/sc/testdocs/index.html is an attached examples of different xls formats . 
[cellformat_import_biff8_12.xls](https://github.com/h2non/filetype/files/13176747/cellformat_import_biff8_12.xls)
[cells_import_biff8_11.xls](https://github.com/h2non/filetype/files/13176748/cells_import_biff8_11.xls)
